### PR TITLE
use the category type for performance wins

### DIFF
--- a/synthpop/categorizer.py
+++ b/synthpop/categorizer.py
@@ -68,7 +68,7 @@ def joint_distribution(sample_df, category_df, mapping_functions):
                                           "mapping function with the same " \
                                           "name to define that category for " \
                                           "the pums sample records"
-        sample_df[name] = sample_df.apply(mapping_functions[name], axis=1)
+        sample_df[name] = sample_df.apply(mapping_functions[name], axis=1).astype('category')
 
     category_df["frequency"] = sample_df.groupby(category_names).size()
     category_df["frequency"] = category_df["frequency"].fillna(0)


### PR DESCRIPTION
So just came across [Categorical Data](http://pandas.pydata.org/pandas-docs/stable/categorical.html) in pandas, and [this blog post on how it dramatically improves performance on data with text categories](http://matthewrocklin.com/blog/work/2015/06/18/Categoricals).

This is not yet tested, but I think it makes sense. What do you think? Are there other places that need it?