### PR TITLE
Update deprecated pandas index diff call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'census>=0.5',
         'numexpr>=2.3.1',
         'numpy>=1.8.0',
-        'pandas>=0.13.1',
+        'pandas>=0.15.0',
         'scipy>=0.13.3',
         'us>=0.8'
     ]

--- a/synthpop/draw.py
+++ b/synthpop/draw.py
@@ -154,7 +154,7 @@ def compare_to_constraints(synth, constraints):
 
     # need to add zeros to counts for any categories that are
     # in the constraints but not in the counts
-    diff = constraints.index.diff(counts.index)
+    diff = constraints.index.difference(counts.index)
     counts = counts.combine_first(
         pd.Series(np.zeros(len(diff), dtype='int'), index=diff))
 


### PR DESCRIPTION
Changing `index.diff` (deprecated in recent pandas versions) to `index.difference`, and bumping the minimum pandas version in setup.py to .15.

Travis jobs have indicated this is an issue. This change is analogous to the one made in the following pull request in the urbansim repo:
https://github.com/UDST/urbansim/pull/179