### PR TITLE
update cat_ids on persons, set index to catids on constraints

### DIFF
--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -84,7 +84,7 @@ class _FrequencyAndConstraints(object):
         keys = set([c[0] for c in self.iter_columns()])
         assert len(set(household_freq.columns) - keys) == 0
         if has_pers:
-            assert len(set(household_freq.columns) - keys) == 0
+            assert len(set(person_freq.columns) - keys) == 0
             assert self.ncols == len(household_freq.columns) + len(person_freq.columns)
 
     def iter_columns(self):

--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -65,7 +65,8 @@ class _FrequencyAndConstraints(object):
         hh_cols = ((key, col, household_constraints[key], nz)
                    for key, col, nz in _drop_zeros(household_freq))
 
-        if person_freq is not None and person_constraints is not None:
+        has_pers = person_freq is not None and person_constraints is not None
+        if has_pers:
             p_cols = ((key, col, person_constraints[key], nz)
                       for key, col, nz in _drop_zeros(person_freq))
         else:
@@ -74,6 +75,17 @@ class _FrequencyAndConstraints(object):
         self._everything = OrderedDict(
             (t[0], t) for t in itertools.chain(hh_cols, p_cols))
         self.ncols = len(self._everything)
+
+        """
+        Check for problems in the resulting keys.
+        These typically arise when column names are shared accross
+        households and persons.
+        """
+        keys = set([c[0] for c in self.iter_columns()])
+        assert len(set(household_freq.columns) - keys) == 0
+        if has_pers:
+            assert len(set(household_freq.columns) - keys) == 0
+            assert self.ncols == len(household_freq.columns) + len(person_freq.columns)
 
     def iter_columns(self):
         """

--- a/synthpop/synthesizer.py
+++ b/synthpop/synthesizer.py
@@ -47,7 +47,7 @@ def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums,
     # ipf for persons
     logger.info("Running ipf for persons")
     p_constraint, _ = calculate_constraints(p_marg, p_jd.frequency)
-    p_constraint.index = p_jd.cat_id
+    # p_constraint.index = p_jd.cat_id
 
     logger.debug("Person constraint")
     logger.debug(p_constraint)
@@ -56,10 +56,7 @@ def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums,
     p_starting_cat_id = h_jd['cat_id'].max() + 1
     p_jd['cat_id'] += p_starting_cat_id
     p_pums['cat_id'] += p_starting_cat_id
-
-    # modify constraint indexes to match cat_ids
-    h_constraint.index = np.arange(len(h_constraint))
-    p_constraint.index = np.arange(len(p_constraint)) + p_starting_cat_id
+    p_constraint.index = p_jd.cat_id
 
     # make frequency tables that the ipu expects
     household_freq, person_freq = cat.frequency_tables(p_pums, h_pums,

--- a/synthpop/synthesizer.py
+++ b/synthpop/synthesizer.py
@@ -52,6 +52,15 @@ def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums,
     logger.debug("Person constraint")
     logger.debug(p_constraint)
 
+    # modify person cat ids so they are unique when combined with households
+    p_starting_cat_id = h_jd['cat_id'].max() + 1
+    p_jd['cat_id'] += p_starting_cat_id
+    p_pums['cat_id'] += p_starting_cat_id
+
+    # modify constraint indexes to match cat_ids
+    h_constraint.index = np.arange(len(h_constraint))
+    p_constraint.index = np.arange(len(p_constraint)) + p_starting_cat_id
+
     # make frequency tables that the ipu expects
     household_freq, person_freq = cat.frequency_tables(p_pums, h_pums,
                                                        p_jd.cat_id,


### PR DESCRIPTION
Attempts to address the issue of person constraints overriding households constraints in the IPU. See https://github.com/UDST/synthpop/issues/33