### PR TITLE
Parallel py3

### DIFF
--- a/synthpop/categorizer.py
+++ b/synthpop/categorizer.py
@@ -8,7 +8,7 @@ import pandas as pd
 def categorize(df, eval_d, index_cols=None):
     cat_df = pd.DataFrame(index=df.index)
 
-    for index, expr in eval_d.iteritems():
+    for index, expr in eval_d.items():
         cat_df[index] = df.eval(expr)
 
     if index_cols is not None:
@@ -51,7 +51,7 @@ def category_combinations(index):
         if len(d[cat_name]) == 1:
             del d[cat_name]
     df = pd.DataFrame(list(itertools.product(*d.values())))
-    df.columns = cols = d.keys()
+    df.columns = cols = list(d.keys())
     df.index.name = "cat_id"
     df = df.reset_index().set_index(cols)
     return df

--- a/synthpop/census_helpers.py
+++ b/synthpop/census_helpers.py
@@ -82,7 +82,7 @@ class Census:
         def chunks(l, n):
             """ Yield successive n-sized chunks from l.
             """
-            for i in xrange(0, len(l), n):
+            for i in range(0, len(l), n):
                 yield l[i:i+n]
 
         for census_column_batch in chunks(census_columns, 45):

--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -99,7 +99,7 @@ class _FrequencyAndConstraints(object):
         The returned column contains only the non-zero elements.
 
         """
-        return self._everything.itervalues()
+        return self._everything.values()
 
     def get_column(self, key):
         """
@@ -259,9 +259,12 @@ def household_weights(
         iterations += 1
 
         if iterations > max_iterations:
-            raise RuntimeError(
-                'Maximum number of iterations reached during IPU: {}'.format(
-                    max_iterations))
+            # raise RuntimeError(
+            #     'Maximum number of iterations reached during IPU: {}'.format(
+            #         max_iterations))
+            return (
+                pd.Series(best_weights, index=household_freq.index),
+                best_fit_qual, iterations)
 
     return (
         pd.Series(best_weights, index=household_freq.index),

--- a/synthpop/recipes/starter2.py
+++ b/synthpop/recipes/starter2.py
@@ -177,8 +177,8 @@ class Starter:
         # that will be in the outputted synthetic population
         self.h_pums_cols = ('serialno', 'PUMA00', 'PUMA10', 'RT', 'NP', 'TYPE',
                             'R65', 'HINCP', 'VEH', 'MV', 'TEN', 'BLD', 'R18')
-        self.p_pums_cols = ('serialno', 'PUMA00', 'PUMA10', 'RELP', 'AGEP',
-                            'ESR', 'RAC1P', 'HISP', 'SEX')
+        self.p_pums_cols = ('serialno', 'SPORDER', 'PUMA00', 'PUMA10', 'RELP', 'AGEP',
+                            'ESR', 'SCHL', 'SCH', 'JWTR', 'PERNP', 'WKHP', 'RAC1P', 'HISP', 'SEX')
 
     def get_geography_name(self):
         # this synthesis is at the block group level for most variables

--- a/synthpop/synthesizer.py
+++ b/synthpop/synthesizer.py
@@ -233,43 +233,9 @@ def synthesize_all_in_parallel(
             break
 
     print('Processing function args in parallel:')
-    for finished_arg in tqdm(as_completed(geog_synth_args), total=len(geog_synth_args)):
+    for finished_arg in tqdm(
+            as_completed(geog_synth_args), total=len(geog_synth_args)):
         finished_args.append(finished_arg.result())
-    # for geog_id in tqdm(indexes, total=recipe.get_num_geographies()):
-    #     # print("Synthesizing geog id:\n", geog_id)
-
-    #     # h_marg = recipe.get_household_marginal_for_geography(geog_id)
-    #     h_marg = ex.submit(recipe.get_household_marginal_for_geography, geog_id)
-    #     logger.debug("Household marginal")
-    #     logger.debug(h_marg)
-
-    #     # p_marg = recipe.get_person_marginal_for_geography(geog_id)
-    #     p_marg = ex.submit(recipe.get_person_marginal_for_geography, geog_id)
-    #     logger.debug("Person marginal")
-    #     logger.debug(p_marg)
-
-    #     # h_pums, h_jd = recipe.\
-    #         # get_household_joint_dist_for_geography(geog_id)
-    #     h_pums, h_jd = ex.submit(recipe.get_household_joint_dist_for_geography, geog_id)
-    #     logger.debug("Household joint distribution")
-    #     logger.debug(h_jd)
-
-    #     # p_pums, p_jd = recipe.get_person_joint_dist_for_geography(geog_id)
-    #     p_pums, p_jd = ex.submit(recipe.get_person_joint_dist_for_geography, geog_id)
-    #     logger.debug("Person joint distribution")
-    #     logger.debug(p_jd)
-    #     # geog_synth_args.append((
-    #     #     h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, marginal_zero_sub,
-    #     #     jd_zero_sub))
-    #     geog_ids.append(geog_id)
-
-    #     future = ex.submit(
-    #         synthesize, h_marg, p_marg, h_jd, p_jd, h_pums, p_pums,
-    #         marginal_zero_sub,jd_zero_sub)
-    #     futures.append(future)
-    #     cnt += 1
-    #     if num_geogs is not None and cnt >= num_geogs:
-    #         break
 
     print('Submitting {0} geographies for parallel processing.'.format(
         len(finished_args)))
@@ -279,8 +245,6 @@ def synthesize_all_in_parallel(
     print('Beginning population synthesis in parallel:')
     for f in tqdm(as_completed(futures), total=len(futures)):
         pass
-
-    # return futures
 
     print('Processing results:')
     for i, future in tqdm(enumerate(futures), total=len(futures)):

--- a/synthpop/synthesizer.py
+++ b/synthpop/synthesizer.py
@@ -5,6 +5,8 @@ from collections import namedtuple
 import numpy as np
 import pandas as pd
 from scipy.stats import chisquare
+from tqdm import tqdm
+from concurrent.futures import ProcessPoolExecutor, as_completed
 
 from . import categorizer as cat
 from . import draw
@@ -67,21 +69,21 @@ def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums,
     logger.info("Running ipu")
     import time
     t1 = time.time()
-    best_weights, fit_quality, iterations = household_weights(household_freq,
-                                                              person_freq,
-                                                              h_constraint,
-                                                              p_constraint)
-    logger.info("Time to run ipu: %.3fs" % (time.time()-t1))
+    max_iterations = 20000
+    best_weights, fit_quality, iterations = household_weights(
+        household_freq, person_freq, h_constraint, p_constraint,
+        max_iterations=max_iterations)
 
+    logger.info("Time to run ipu: %.3fs" % (time.time() - t1))
     logger.debug("IPU weights:")
     logger.debug(best_weights.describe())
-    logger.debug("Fit quality:")
-    logger.debug(fit_quality)
-    logger.debug("Number of iterations:")
-    logger.debug(iterations)
-
+    logger.debug("Fit quality: {0}".format(fit_quality))
+    if iterations == 20000:
+        logger.warn("Number of iterations: {0}".format(str(iterations)))
+    else:
+        logger.debug("Number of iterations: {0}".format(str(iterations)))
     num_households = int(h_marg.groupby(level=0).sum().mean())
-    print "Drawing %d households" % num_households
+    # print("Drawing %d households" % num_households)
 
     best_chisq = np.inf
 
@@ -102,8 +104,8 @@ def synthesize_all(recipe, num_geogs=None, indexes=None,
         and ``people_p``.
 
     """
-    print "Synthesizing at geog level: '{}' (number of geographies is {})".\
-        format(recipe.get_geography_name(), recipe.get_num_geographies())
+    # print("Synthesizing at geog level: '{}' (number of geographies is {})".\
+        # format(recipe.get_geography_name(), recipe.get_num_geographies()))
 
     if indexes is None:
         indexes = recipe.get_available_geography_ids()
@@ -115,8 +117,8 @@ def synthesize_all(recipe, num_geogs=None, indexes=None,
     hh_index_start = 0
 
     # TODO will parallelization work here?
-    for geog_id in indexes:
-        print "Synthesizing geog id:\n", geog_id
+    for geog_id in tqdm(indexes, total=recipe.get_num_geographies()):
+        # print("Synthesizing geog id:\n", geog_id)
 
         h_marg = recipe.get_household_marginal_for_geography(geog_id)
         logger.debug("Household marginal")
@@ -158,6 +160,155 @@ def synthesize_all(recipe, num_geogs=None, indexes=None,
 
         if num_geogs is not None and cnt >= num_geogs:
             break
+
+    # TODO might want to write this to disk as we go?
+    all_households = pd.concat(hh_list)
+    all_persons = pd.concat(people_list, ignore_index=True)
+
+    return (all_households, all_persons, fit_quality)
+
+
+def geog_preprocessing(geog_id, recipe, marginal_zero_sub, jd_zero_sub):
+    h_marg = recipe.get_household_marginal_for_geography(geog_id)
+    logger.debug("Household marginal")
+    logger.debug(h_marg)
+
+    p_marg = recipe.get_person_marginal_for_geography(geog_id)
+    logger.debug("Person marginal")
+    logger.debug(p_marg)
+
+    h_pums, h_jd = recipe.\
+        get_household_joint_dist_for_geography(geog_id)
+    logger.debug("Household joint distribution")
+    logger.debug(h_jd)
+
+    p_pums, p_jd = recipe.get_person_joint_dist_for_geography(geog_id)
+    logger.debug("Person joint distribution")
+    logger.debug(p_jd)
+
+    return h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, marginal_zero_sub,\
+        jd_zero_sub
+
+
+def synthesize_all_in_parallel(
+        recipe, num_geogs=None, indexes=None, marginal_zero_sub=.01,
+        jd_zero_sub=.001):
+    """
+    Returns
+    -------
+    households, people : pandas.DataFrame
+    fit_quality : dict of FitQuality
+        Keys are geographic IDs, values are namedtuples with attributes
+        ``.household_chisq``, ``household_p``, ``people_chisq``,
+        and ``people_p``.
+
+    """
+    # cluster = LocalCluster()
+    # client = Client(cluster)
+    ex = ProcessPoolExecutor()
+
+    if indexes is None:
+        indexes = recipe.get_available_geography_ids()
+
+    hh_list = []
+    people_list = []
+    cnt = 0
+    fit_quality = {}
+    hh_index_start = 0
+
+    # TODO will parallelization work here?
+    geog_synth_args = []
+    finished_args = []
+    geog_ids = []
+    futures = []
+
+    print('Submitting function args for parallel processing:')
+    for i, geog_id in enumerate(indexes):
+        geog_synth_args.append(ex.submit(
+            geog_preprocessing, geog_id, recipe, marginal_zero_sub,
+            jd_zero_sub))
+        geog_ids.append(geog_id)
+        cnt += 1
+        if num_geogs is not None and cnt >= num_geogs:
+            break
+
+    print('Processing function args in parallel:')
+    for finished_arg in tqdm(as_completed(geog_synth_args), total=len(geog_synth_args)):
+        finished_args.append(finished_arg.result())
+    # for geog_id in tqdm(indexes, total=recipe.get_num_geographies()):
+    #     # print("Synthesizing geog id:\n", geog_id)
+
+    #     # h_marg = recipe.get_household_marginal_for_geography(geog_id)
+    #     h_marg = ex.submit(recipe.get_household_marginal_for_geography, geog_id)
+    #     logger.debug("Household marginal")
+    #     logger.debug(h_marg)
+
+    #     # p_marg = recipe.get_person_marginal_for_geography(geog_id)
+    #     p_marg = ex.submit(recipe.get_person_marginal_for_geography, geog_id)
+    #     logger.debug("Person marginal")
+    #     logger.debug(p_marg)
+
+    #     # h_pums, h_jd = recipe.\
+    #         # get_household_joint_dist_for_geography(geog_id)
+    #     h_pums, h_jd = ex.submit(recipe.get_household_joint_dist_for_geography, geog_id)
+    #     logger.debug("Household joint distribution")
+    #     logger.debug(h_jd)
+
+    #     # p_pums, p_jd = recipe.get_person_joint_dist_for_geography(geog_id)
+    #     p_pums, p_jd = ex.submit(recipe.get_person_joint_dist_for_geography, geog_id)
+    #     logger.debug("Person joint distribution")
+    #     logger.debug(p_jd)
+    #     # geog_synth_args.append((
+    #     #     h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, marginal_zero_sub,
+    #     #     jd_zero_sub))
+    #     geog_ids.append(geog_id)
+
+    #     future = ex.submit(
+    #         synthesize, h_marg, p_marg, h_jd, p_jd, h_pums, p_pums,
+    #         marginal_zero_sub,jd_zero_sub)
+    #     futures.append(future)
+    #     cnt += 1
+    #     if num_geogs is not None and cnt >= num_geogs:
+    #         break
+
+    print('Submitting {0} geographies for parallel processing.'.format(
+        len(finished_args)))
+    futures = [
+        ex.submit(synthesize, *geog_args) for geog_args in finished_args]
+
+    print('Beginning population synthesis in parallel:')
+    for f in tqdm(as_completed(futures), total=len(futures)):
+        pass
+
+    # return futures
+
+    print('Processing results:')
+    for i, future in tqdm(enumerate(futures), total=len(futures)):
+        try:
+            households, people, people_chisq, people_p = future.result()
+        except Exception as e:
+            print('Generated an exception: {0}'.format(e))
+        else:
+            geog_id = geog_ids[i]
+
+            # Append location identifiers to the synthesized households
+            for geog_cat in geog_id.keys():
+                households[geog_cat] = geog_id[geog_cat]
+
+            # update the household_ids since we can't do it in the call to
+            # synthesize when we execute in parallel
+            households.index += hh_index_start
+            people.hh_id += hh_index_start
+
+            hh_list.append(households)
+            people_list.append(people)
+            key = BlockGroupID(
+                geog_id['state'], geog_id['county'], geog_id['tract'],
+                geog_id['block group'])
+            fit_quality[key] = FitQuality(people_chisq, people_p)
+
+            if len(households) > 0:
+                hh_index_start = households.index.values[-1] + 1
 
     # TODO might want to write this to disk as we go?
     all_households = pd.concat(hh_list)


### PR DESCRIPTION
- updated synthpop for python 3
- updated the census attributes retained in **starter2.py**
- updated **ipu.py** so that rather than erroring out when `max_iterations` is reached, it generates a warning.
- added method `synthesize_all_in_parallel()` to **synthesizer.py** for processing sub-county geographies in parallel.

Could use an extra set of eyes at L264-265 in **synthesizer.py**. These two lines account for the fact that when processing geographies in parallel, `draw.draw_households()` cannot rely on the `hh_index_start` argument to set the `household_id` either as the index of the synthetic households table or the `hh_id` field of the synthetic persons table. Thus we have to adjust the households index and persons `hh_id` field AFTER all the tables have been generated, which is what's hapenning at L264-265.