### PR TITLE
Add pums column names for parcel template schema

### DIFF
--- a/synthpop/recipes/starter2.py
+++ b/synthpop/recipes/starter2.py
@@ -182,8 +182,8 @@ class Starter:
         self.h_pums_cols = ('serialno', 'PUMA00', 'PUMA10', 'RT', 'NP', 'TYPE',
                             'R65', 'HINCP', 'VEH', 'MV', 'TEN', 'BLD', 'R18')
         self.p_pums_cols = ('serialno', 'PUMA00', 'PUMA10', 'RELP', 'AGEP',
-                            'ESR', 'RAC1P', 'HISP', 'SEX','SPORDER',
-                            'PERNP','SCHL','WKHP','JWTR','SCH')
+                            'ESR', 'RAC1P', 'HISP', 'SEX', 'SPORDER',
+                            'PERNP', 'SCHL', 'WKHP', 'JWTR', 'SCH')
 
     def get_geography_name(self):
         # this synthesis is at the block group level for most variables

--- a/synthpop/recipes/starter2.py
+++ b/synthpop/recipes/starter2.py
@@ -182,7 +182,8 @@ class Starter:
         self.h_pums_cols = ('serialno', 'PUMA00', 'PUMA10', 'RT', 'NP', 'TYPE',
                             'R65', 'HINCP', 'VEH', 'MV', 'TEN', 'BLD', 'R18')
         self.p_pums_cols = ('serialno', 'PUMA00', 'PUMA10', 'RELP', 'AGEP',
-                            'ESR', 'RAC1P', 'HISP', 'SEX')
+                            'ESR', 'RAC1P', 'HISP', 'SEX','SPORDER',
+                            'PERNP','SCHL','WKHP','JWTR','SCH')
 
     def get_geography_name(self):
         # this synthesis is at the block group level for most variables


### PR DESCRIPTION
Added new pums columns in the starter2 script. These columns will be used to create columns later used in the simulation according to the documentation.