### PR TITLE
Add dtype serialno

### DIFF
--- a/synthpop/census_helpers.py
+++ b/synthpop/census_helpers.py
@@ -174,7 +174,8 @@ class Census:
                 "PUMA10": "object",
                 "PUMA00": "object",
                 "ST": "object",
-                "SERIALNO": 'str'
+                "SERIALNO": 'str',
+                "serialno": 'str',
             }, **kargs)
             pums_df = pums_df.rename(columns={
                 'PUMA10': 'puma10',


### PR DESCRIPTION
Adds a data type to serialno column when reading PUMS. 
@PyMap it deletes also some printings, are we still using them?