### PR TITLE
Update Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,21 @@
 language: python
-sudo: false
+
 python:
-- '2.7'
-- '3.5'
+  - '2.7'
+  - '3.5'
+  - '3.6'
+  - '3.7'
+  - '3.8'
+
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-  -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  -O miniconda.sh; fi
-- bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda info -a
-- |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numexpr numpy pandas scipy pytest
-- source activate test-environment
-- pip install pytest-cov coveralls pep8
-- pip install .
+  - pip install .
+  - pip install -r requirements-dev.txt
+  - pip list
+  - pip show synthpop
+
 script:
-- pep8 synthpop
-- py.test --cov synthpop --cov-report term-missing
+  - pycodestyle synthpop
+  - py.test --cov synthpop --cov-report term-missing
+
 after_success:
 - coveralls
-notifications:
-  slack:
-    secure: AauAe1pvhJ/siv7ed2j34NAubBAMA9FaMuw7nFWk6i0lKQmhMh3ykqWY39OINpHe+4GJnedTpJQ1foZGYPSMZn5euEDqdtsg7SCzVQhlwFwD9jJ9a55HyZx6awYAbaxwGuSkrQ3glrSzG02ZgO9FnhCqAKk4TH9SI/sdEZ7W/7A=

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
   - py.test --cov synthpop --cov-report term-missing
 
 after_success:
-- coveralls
+  - coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,12 @@
+# Additional requirements for development and testing
+
+# testing
+coveralls
+pytest
+pytest-cov
+pycodestyle
+
+# building documentation
+numpydoc
+sphinx
+sphinx_rtd_theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 # testing
 coveralls
 pytest
-pytest-cov
+pytest-cov<2.10  # 2.10 raised errors in Travis
 pycodestyle
 
 # building documentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [pycodestyle]
-ignore = E226,E402,E722,E741
+# these are the standard ignores plus E402, E722, and E741, which weren't enforced when
+# the codebase was first written
+ignore = E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505,E402,E722,E741
 max-line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
-[pep8]
+[pycodestyle]
+ignore = E226,E402,E722,E741
 max-line-length = 100

--- a/synthpop/ipu/test/test_ipu.py
+++ b/synthpop/ipu/test/test_ipu.py
@@ -128,7 +128,7 @@ def test_update_weights(
         household_freqs, person_freqs, household_constraints,
         person_constraints):
     column = household_freqs[('yes', 'blue')]
-    column = column.iloc[column.nonzero()[0]]
+    column = column.iloc[column.values.nonzero()[0]]
     constraint = household_constraints[('yes', 'blue')]
     weights = pd.Series(
         np.ones(len(column)),
@@ -140,7 +140,7 @@ def test_update_weights(
         atol=0.01)
 
     column = person_freqs[(9, 'pink')]
-    column = column.iloc[column.nonzero()[0]]
+    column = column.iloc[column.values.nonzero()[0]]
     constraint = person_constraints[(9, 'pink')]
     weights = pd.Series(
         [8.05, 9.51, 8.05, 10.59, 11.0, 8.97, 8.97, 8.97],
@@ -159,7 +159,7 @@ def test_household_weights(
         household_freqs, person_freqs, household_constraints,
         person_constraints, convergence=1e-7)
     npt.assert_allclose(
-        weights.as_matrix(),
+        weights.values,
         [1.36, 25.66, 7.98, 27.79, 18.45, 8.64, 1.47, 8.64],
         atol=0.02)
     npt.assert_allclose(fit_qual, 8.51e-6, atol=1e-8)

--- a/synthpop/zone_synthesizer.py
+++ b/synthpop/zone_synthesizer.py
@@ -39,15 +39,15 @@ def load_data(hh_marginal_file, person_marginal_file,
     p_sample = pd.read_csv(person_sample_file)
 
     hh_marg = pd.read_csv(hh_marginal_file, header=[0, 1], index_col=0)
-    hh_marg.columns.levels[0].name = 'cat_name'
-    hh_marg.columns.levels[1].name = 'cat_values'
+    hh_marg.columns.levels[0].set_names('cat_name', inplace=True)
+    hh_marg.columns.levels[1].set_names('cat_values', inplace=True)
 
     xwalk = list(zip(hh_marg.index, hh_marg.sample_geog.unstack().values))
     hh_marg = hh_marg.drop('sample_geog', axis=1, level=0)
 
     p_marg = pd.read_csv(person_marginal_file, header=[0, 1], index_col=0)
-    p_marg.columns.levels[0].name = 'cat_name'
-    p_marg.columns.levels[1].name = 'cat_values'
+    p_marg.columns.levels[0].set_names('cat_name', inplace=True)
+    p_marg.columns.levels[1].set_names('cat_values', inplace=True)
 
     return hh_marg, p_marg, hh_sample, p_sample, xwalk
 


### PR DESCRIPTION
This PR updates the Travis script, to simplify it and run tests in newer Python environments. Also updates some other ancillary things that came up in the process.

### Travis script

Old version: [.travis.yml](https://github.com/UDST/synthpop/blob/f8dbfc4aa9c4ac1fff8d1395587d8de06a05fa47/.travis.yml)  
New version: [.travis.yml](https://github.com/UDST/synthpop/blob/991102b766fa5fa76c599eda98bc0af84b9a909c/.travis.yml)

This runs the same code style and unit tests, removing some outdated cruft -- replaces a Conda custom environment with `pip install .`, drops an old slack notification system, etc. Tests now run in Python 2.7, 3.5, 3.6, 3.7, and 3.8.

Python 3.6+ will use current versions of Pandas and NumPy, but earlier environments will use older versions, which is helpful for maintaining backward compatibility.

### Pandana syntax

Running the tests in newer environments raised a few errors related to Pandas deprecations, which I fixed:
- `pd.Series.nonzero()` -> `pd.Series.values.nonzero()`
- `pd.Series.as_matrix()` -> `pd.Series.values()`
- `pd.Index.name =` -> `pd.Index.set_names()`

### Other changes

- added a `requirements-dev.txt` file to list the additional packages used for testing in a central place
- switched the code style checks from pep8 to pycodestyle
