### PR TITLE
Ipu20000

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 sudo: false
 python:
-- '2.7'
+#- '2.7'
 - '3.5'
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-  -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  -O miniconda.sh; fi
+#- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
+  #-O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  #-O miniconda.sh; fi
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,20 @@
 language: python
-sudo: false
+
 python:
-- '2.7'
-- '3.5'
+  - '3.5'
+  - '3.6'
+  - '3.7'
+  - '3.8'
+
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-  -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  -O miniconda.sh; fi
-- bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda info -a
-- |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numexpr numpy pandas scipy pytest
-- source activate test-environment
-- pip install pytest-cov coveralls pep8
-- pip install .
+  - pip install .
+  - pip install -r requirements-dev.txt
+  - pip list
+  - pip show synthpop
+
 script:
-- pep8 synthpop
-- py.test --cov synthpop --cov-report term-missing
+  - pycodestyle synthpop
+  - py.test --cov synthpop --cov-report term-missing
+
 after_success:
-- coveralls
-notifications:
-  slack:
-    secure: AauAe1pvhJ/siv7ed2j34NAubBAMA9FaMuw7nFWk6i0lKQmhMh3ykqWY39OINpHe+4GJnedTpJQ1foZGYPSMZn5euEDqdtsg7SCzVQhlwFwD9jJ9a55HyZx6awYAbaxwGuSkrQ3glrSzG02ZgO9FnhCqAKk4TH9SI/sdEZ7W/7A=
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 sudo: false
 python:
-#- '2.7'
+- '2.7'
 - '3.5'
 install:
-#- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-  #-O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  #-O miniconda.sh; fi
+- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
+  -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  -O miniconda.sh; fi
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - hash -r

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
         'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
     ],
     packages=find_packages(exclude=['*.tests']),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         'census>=0.5',
         'numexpr>=2.3.1',
-        'numpy>=1.8.0',
+        'numpy>=1.16.5 ',
         'pandas>=0.15.0',
         'scipy>=0.13.3',
         'us>=0.8'

--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
+import pdb
 
 def _drop_zeros(df):
     """
@@ -261,6 +262,8 @@ def household_weights(
         fit_qual = new_fit_qual
         iterations += 1
 
+        pdb.set_trace()
+
         if iterations > max_iterations:
             if ignore_max_iters:
                 fitting_tolerance = fit_change - convergence
@@ -269,8 +272,14 @@ def household_weights(
                             'fit_change': fit_change,
                             'fitting_tolerance': fitting_tolerance,
                             'geog_id': geography}
-                np.save('max_iter_{}_{}_{}_{}.npy'.format(geography['state'], geography['county'],
-                                                          geography['tract'], geography['block group']), ipu_dict)
+                if isinstance(geography, pd.Series):
+                    np.save('max_iter_{}_{}_{}_{}.npy'.format(geography['state'], geography['county'],
+                                                              geography['tract'], geography['block group']), ipu_dict)
+                elif isinstance(geography, list):
+                    np.save('max_iter_{}_{}.npy'.format(geography[0], geography[1]), ipu_dict)
+                else:
+                    np.save('max_iter_{}.npy'.format(str(geography)), ipu_dict)
+
                 warnings.warn(
                     'Maximum number of iterations reached '
                     'during IPU: {}'.format(max_iterations), UserWarning)

--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -9,8 +9,6 @@ import warnings
 import numpy as np
 import pandas as pd
 
-import pdb
-
 def _drop_zeros(df):
     """
     Drop zeros from a DataFrame, returning an iterator over the columns
@@ -261,8 +259,6 @@ def household_weights(
 
         fit_qual = new_fit_qual
         iterations += 1
-
-        pdb.set_trace()
 
         if iterations > max_iterations:
             if ignore_max_iters:

--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -195,8 +195,8 @@ def _update_weights(column, weights, constraint):
 
 def household_weights(
         household_freq, person_freq, household_constraints,
-        person_constraints, geography,
-        convergence=1e-4, max_iterations=20000, ignore_max_iters=True):
+        person_constraints, geography, ignore_max_iters,
+        convergence=1e-4, max_iterations=20000):
     """
     Calculate the household weights that best match household and
     person level attributes.

--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -275,7 +275,7 @@ def household_weights(
                     'Maximum number of iterations reached '
                     'during IPU: {}'.format(max_iterations), UserWarning)
                 return (
-                    pd.Series(best_weights, index=hf.index),
+                    pd.Series(best_weights, index=household_freq.index),
                     best_fit_qual, iterations)
             else:
                 raise RuntimeError(

--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -23,10 +23,10 @@ def _drop_zeros(df):
 
     """
     def for_each_col(col):
-        nz = col.nonzero()[0]
-        return col[nz], nz
+        nz = col.values.nonzero()[0]
+        return col.iloc[nz], nz
 
-    for (col_idx, (col, nz)) in df.apply(for_each_col, axis=0, raw=True).items():
+    for (col_idx, (col, nz)) in df.apply(for_each_col, axis=0, raw=False).items():
         yield (col_idx, col, nz)
 
 

--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -26,7 +26,7 @@ def _drop_zeros(df):
         return col.iloc[nz], nz
 
     for (col_idx, (col, nz)) in df.apply(for_each_col, axis=0, raw=False).items():
-        yield (col_idx, col, nz)
+        yield (col_idx, col.values, nz)
 
 
 class _FrequencyAndConstraints(object):

--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -4,6 +4,7 @@ from __future__ import division
 
 import itertools
 from collections import OrderedDict
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -60,9 +61,10 @@ class _FrequencyAndConstraints(object):
     Attributes
     ----------
     ncols : int
-        Total number of columns across household and person classes.
+        Total number household_wof columns across household and person classes.
 
     """
+
     def __init__(self, household_freq, household_constraints, person_freq=None,
                  person_constraints=None):
         hh_cols = ((key, col, household_constraints[key], nz)
@@ -161,7 +163,7 @@ def _average_fit_quality(freq_wrap, weights):
     return sum(
         _fit_quality(col, weights[nz], constraint)
         for _, col, constraint, nz in freq_wrap.iter_columns()
-        ) / freq_wrap.ncols
+    ) / freq_wrap.ncols
 
 
 def _update_weights(column, weights, constraint):
@@ -192,8 +194,9 @@ def _update_weights(column, weights, constraint):
 
 
 def household_weights(
-        household_freq, person_freq, household_constraints, person_constraints,
-        convergence=1e-4, max_iterations=20000):
+        household_freq, person_freq, household_constraints,
+        person_constraints, geography,
+        convergence=1e-4, max_iterations=20000, ignore_max_iters=True):
     """
     Calculate the household weights that best match household and
     person level attributes.
@@ -259,9 +262,25 @@ def household_weights(
         iterations += 1
 
         if iterations > max_iterations:
-            raise RuntimeError(
-                'Maximum number of iterations reached during IPU: {}'.format(
-                    max_iterations))
+            if ignore_max_iters:
+                fitting_tolerance = fit_change - convergence
+                print('Fitting tolerance before 20000 iterations: %s' % str(fitting_tolerance))
+                ipu_dict = {'best_fit_qual': best_fit_qual,
+                            'fit_change': fit_change,
+                            'fitting_tolerance': fitting_tolerance,
+                            'geog_id': geography}
+                np.save('max_iter_{}_{}_{}_{}.npy'.format(geography['state'], geography['county'],
+                                                          geography['tract'], geography['block group']), ipu_dict)
+                warnings.warn(
+                    'Maximum number of iterations reached '
+                    'during IPU: {}'.format(max_iterations), UserWarning)
+                return (
+                    pd.Series(best_weights, index=hf.index),
+                    best_fit_qual, iterations)
+            else:
+                raise RuntimeError(
+                    'Maximum number of iterations reached '
+                    'during IPU: {}'.format(max_iterations))
 
     return (
         pd.Series(best_weights, index=household_freq.index),

--- a/synthpop/ipu/ipu.py
+++ b/synthpop/ipu/ipu.py
@@ -9,6 +9,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
+
 def _drop_zeros(df):
     """
     Drop zeros from a DataFrame, returning an iterator over the columns
@@ -269,8 +270,10 @@ def household_weights(
                             'fitting_tolerance': fitting_tolerance,
                             'geog_id': geography}
                 if isinstance(geography, pd.Series):
-                    np.save('max_iter_{}_{}_{}_{}.npy'.format(geography['state'], geography['county'],
-                                                              geography['tract'], geography['block group']), ipu_dict)
+                    state, county = geography['state'], geography['county']
+                    tract, bgroup = geography['tract'], geography['block group']
+                    np.save('max_iter_{}_{}_{}_{}.npy'.format(state, county,
+                                                              tract, bgroup), ipu_dict)
                 elif isinstance(geography, list):
                     np.save('max_iter_{}_{}.npy'.format(geography[0], geography[1]), ipu_dict)
                 else:

--- a/synthpop/ipu/test/test_ipu.py
+++ b/synthpop/ipu/test/test_ipu.py
@@ -161,7 +161,7 @@ def test_update_weights(
 
 def test_household_weights(
         household_freqs, person_freqs, household_constraints,
-        person_constraints,geography, ignore_max_iters=False):
+        person_constraints, geography, ignore_max_iters=False):
     weights, fit_qual, iterations = ipu.household_weights(
         household_freqs, person_freqs, household_constraints,
         person_constraints, geography, ignore_max_iters, convergence=1e-7)

--- a/synthpop/ipu/test/test_ipu.py
+++ b/synthpop/ipu/test/test_ipu.py
@@ -1,6 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
+import random
 import pytest
 from pandas.util import testing as pdt
 
@@ -62,10 +63,18 @@ def person_constraints(person_columns):
 
 @pytest.fixture(scope='module')
 def geography():
-    return pd.Series({'state': '02',
-                      'county': '270',
-                      'tract': '000100',
-                      'block group': '1'})
+    dtypes = ['serie', 'list']
+    dtype = random.choice(dtypes)
+
+    if dtype == 'serie':
+        geography = pd.Series({'state': '02',
+                               'county': '270',
+                               'tract': '000100',
+                               'block group': '1'})
+    else:
+        geography = ['02', '270']
+
+    return geography
 
 
 @pytest.fixture

--- a/synthpop/ipu/test/test_ipu.py
+++ b/synthpop/ipu/test/test_ipu.py
@@ -157,7 +157,7 @@ def test_household_weights(
         person_constraints,geography, ignore_max_iters):
     weights, fit_qual, iterations = ipu.household_weights(
         household_freqs, person_freqs, household_constraints,
-        person_constraints, convergence=1e-7)
+        person_constraints, geography, ignore_max_iters, convergence=1e-7)
     npt.assert_allclose(
         weights.as_matrix(),
         [1.36, 25.66, 7.98, 27.79, 18.45, 8.64, 1.47, 8.64],

--- a/synthpop/ipu/test/test_ipu.py
+++ b/synthpop/ipu/test/test_ipu.py
@@ -154,7 +154,7 @@ def test_update_weights(
 
 def test_household_weights(
         household_freqs, person_freqs, household_constraints,
-        person_constraints):
+        person_constraints,geography, ignore_max_iters):
     weights, fit_qual, iterations = ipu.household_weights(
         household_freqs, person_freqs, household_constraints,
         person_constraints, convergence=1e-7)
@@ -168,11 +168,11 @@ def test_household_weights(
 
 def test_household_weights_max_iter(
         household_freqs, person_freqs, household_constraints,
-        person_constraints):
+        person_constraints,geography, ignore_max_iters):
     with pytest.raises(RuntimeError):
         ipu.household_weights(
             household_freqs, person_freqs, household_constraints,
-            person_constraints, convergence=1e-7, max_iterations=10)
+            person_constraints, geography, ignore_max_iters, convergence=1e-7, max_iterations=10)
 
 
 def test_FrequencyAndConstraints(freq_wrap):

--- a/synthpop/ipu/test/test_ipu.py
+++ b/synthpop/ipu/test/test_ipu.py
@@ -60,6 +60,13 @@ def person_constraints(person_columns):
     return pd.Series([91, 65, 104], index=person_columns)
 
 
+@pytest.fixture(scope='module')
+def geography():
+    return pd.Series({'state': '02',
+                      'county':'270',
+                      'tract':'000100',
+                      'block group': '1'})
+
 @pytest.fixture
 def freq_wrap(
         household_freqs, person_freqs, household_constraints,
@@ -154,7 +161,7 @@ def test_update_weights(
 
 def test_household_weights(
         household_freqs, person_freqs, household_constraints,
-        person_constraints,geography, ignore_max_iters):
+        person_constraints,geography, ignore_max_iters=False):
     weights, fit_qual, iterations = ipu.household_weights(
         household_freqs, person_freqs, household_constraints,
         person_constraints, geography, ignore_max_iters, convergence=1e-7)
@@ -168,7 +175,7 @@ def test_household_weights(
 
 def test_household_weights_max_iter(
         household_freqs, person_freqs, household_constraints,
-        person_constraints,geography, ignore_max_iters):
+        person_constraints, geography, ignore_max_iters=False):
     with pytest.raises(RuntimeError):
         ipu.household_weights(
             household_freqs, person_freqs, household_constraints,

--- a/synthpop/ipu/test/test_ipu.py
+++ b/synthpop/ipu/test/test_ipu.py
@@ -63,9 +63,10 @@ def person_constraints(person_columns):
 @pytest.fixture(scope='module')
 def geography():
     return pd.Series({'state': '02',
-                      'county':'270',
-                      'tract':'000100',
+                      'county': '270',
+                      'tract': '000100',
                       'block group': '1'})
+
 
 @pytest.fixture
 def freq_wrap(

--- a/synthpop/synthesizer.py
+++ b/synthpop/synthesizer.py
@@ -92,7 +92,7 @@ def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, geography, ignore_max
         p_constraint, best_weights, hh_index_start=hh_index_start)
 
 
-def synthesize_all(recipe, num_geogs=None, indexes=None, ignore_max_iters = True,
+def synthesize_all(recipe, num_geogs=None, indexes=None, ignore_max_iters=True,
                    marginal_zero_sub=.01, jd_zero_sub=.001):
     """
     Returns

--- a/synthpop/synthesizer.py
+++ b/synthpop/synthesizer.py
@@ -92,7 +92,7 @@ def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, geography, ignore_max
         p_constraint, best_weights, hh_index_start=hh_index_start)
 
 
-def synthesize_all(recipe, num_geogs=None, indexes=None, ignore_max_iters=True,
+def synthesize_all(recipe, num_geogs=None, indexes=None, ignore_max_iters=False,
                    marginal_zero_sub=.01, jd_zero_sub=.001):
     """
     Returns

--- a/synthpop/synthesizer.py
+++ b/synthpop/synthesizer.py
@@ -25,7 +25,7 @@ def enable_logging():
     logger.setLevel(logging.DEBUG)
 
 
-def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums,
+def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, geography,
                marginal_zero_sub=.01, jd_zero_sub=.001, hh_index_start=0):
 
     # this is the zero marginal problem
@@ -70,7 +70,8 @@ def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums,
     best_weights, fit_quality, iterations = household_weights(household_freq,
                                                               person_freq,
                                                               h_constraint,
-                                                              p_constraint)
+                                                              p_constraint,
+                                                              geography)
     logger.info("Time to run ipu: %.3fs" % (time.time()-t1))
 
     logger.debug("IPU weights:")
@@ -137,7 +138,7 @@ def synthesize_all(recipe, num_geogs=None, indexes=None,
 
         households, people, people_chisq, people_p = \
             synthesize(
-                h_marg, p_marg, h_jd, p_jd, h_pums, p_pums,
+                h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, geog_id,
                 marginal_zero_sub=marginal_zero_sub, jd_zero_sub=jd_zero_sub,
                 hh_index_start=hh_index_start)
 

--- a/synthpop/synthesizer.py
+++ b/synthpop/synthesizer.py
@@ -25,7 +25,7 @@ def enable_logging():
     logger.setLevel(logging.DEBUG)
 
 
-def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, geography,
+def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, geography, ignore_max_iters,
                marginal_zero_sub=.01, jd_zero_sub=.001, hh_index_start=0):
 
     # this is the zero marginal problem
@@ -71,7 +71,8 @@ def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, geography,
                                                               person_freq,
                                                               h_constraint,
                                                               p_constraint,
-                                                              geography)
+                                                              geography,
+                                                              ignore_max_iters)
     logger.info("Time to run ipu: %.3fs" % (time.time()-t1))
 
     logger.debug("IPU weights:")
@@ -91,7 +92,7 @@ def synthesize(h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, geography,
         p_constraint, best_weights, hh_index_start=hh_index_start)
 
 
-def synthesize_all(recipe, num_geogs=None, indexes=None,
+def synthesize_all(recipe, num_geogs=None, indexes=None, ignore_max_iters = True,
                    marginal_zero_sub=.01, jd_zero_sub=.001):
     """
     Returns
@@ -138,7 +139,7 @@ def synthesize_all(recipe, num_geogs=None, indexes=None,
 
         households, people, people_chisq, people_p = \
             synthesize(
-                h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, geog_id,
+                h_marg, p_marg, h_jd, p_jd, h_pums, p_pums, geog_id, ignore_max_iters,
                 marginal_zero_sub=marginal_zero_sub, jd_zero_sub=jd_zero_sub,
                 hh_index_start=hh_index_start)
 

--- a/synthpop/zone_synthesizer.py
+++ b/synthpop/zone_synthesizer.py
@@ -158,7 +158,7 @@ def synthesize_zone(hh_marg, p_marg, hh_sample, p_sample, xwalk):
             cat.category_combinations(p_marg.columns))
     households, people, people_chisq, people_p = synthesize(
             hh_marg.loc[xwalk[0]], p_marg.loc[xwalk[0]], hh_jd, p_jd, hhs, ps, xwalk[0],
-            hh_index_start=1)
+            ignore_max_iters=False, hh_index_start=1)
     households['geog'] = xwalk[0]
     people['geog'] = xwalk[0]
     stats = {'geog': xwalk[0], 'chi-square': people_chisq, 'p-score': people_p}

--- a/synthpop/zone_synthesizer.py
+++ b/synthpop/zone_synthesizer.py
@@ -157,7 +157,7 @@ def synthesize_zone(hh_marg, p_marg, hh_sample, p_sample, xwalk):
             p_sample[p_sample.sample_geog == xwalk[1]],
             cat.category_combinations(p_marg.columns))
     households, people, people_chisq, people_p = synthesize(
-            hh_marg.loc[xwalk[0]], p_marg.loc[xwalk[0]], hh_jd, p_jd, hhs, ps,
+            hh_marg.loc[xwalk[0]], p_marg.loc[xwalk[0]], hh_jd, p_jd, hhs, ps, xwalk[0],
             hh_index_start=1)
     households['geog'] = xwalk[0]
     people['geog'] = xwalk[0]

--- a/synthpop/zone_synthesizer.py
+++ b/synthpop/zone_synthesizer.py
@@ -207,4 +207,4 @@ def multiprocess_synthesize(hh_marg, p_marg, hh_sample,
     all_households = pd.concat(hh_list)
     all_persons = pd.concat(people_list)
     all_households, all_persons = synch_hhids(all_households, all_persons)
-    return all_persons, all_households, all_stats
+    return all_households, all_persons,  all_stats


### PR DESCRIPTION
Move `ignore_max_iters` boolean parameter from `household_weights` to `synthesize_all` method.

Main purpose of this change is to be able to decide if synthesis breaks or continues by exporting `npy` files to analyze block groups that didn't reach convergence.